### PR TITLE
add simple mecanism to 'translate' text in the app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 config.json
+translation/messages.js
 node_modules/

--- a/Commands/Developer/ping.js
+++ b/Commands/Developer/ping.js
@@ -5,7 +5,6 @@ module.exports = {
   description: "Ping",
   permission: "ADMINISTRATOR",
   /**
-   *
    * @param {CommandInteraction} interaction
    */
   execute(interaction) {

--- a/Commands/Users/licence.js
+++ b/Commands/Users/licence.js
@@ -1,4 +1,5 @@
 const { mainRoleId, newMemberRoleId, structureId, licences } = require('../../config.json')
+const { TRANSLATION_LICENCE } = require('../../translation/messages.js')
 
 const fetch = require('node-fetch');
 
@@ -12,7 +13,7 @@ module.exports = {
   options: [
     {
       name: "licence",
-      description: "Renseignez votre numéro de licence FFVL pour rejoindre le discord des Z'éléph",
+      description: TRANSLATION_LICENCE.commandDescription(),
       type: "STRING",
       required: true,
     }
@@ -52,12 +53,7 @@ module.exports = {
     //si le membre a déjà sa licence valide pour l'année
     if(member.roles.cache.some(role => role.name == 'Licencié '+year)) {
       Response.setColor("GREEN")
-      Response.setDescription(`
-        🐘 Ta licence ${year} est déjà validée, tout est bon pour cette année.
-
-        Bon vols !
-        `
-        )
+      Response.setDescription(TRANSLATION_LICENCE.alreadyValidDescription(year))
       console.log(`${member.user.username } : licence déjà valide`);
       interaction.editReply({embeds: [Response]})
     } else {
@@ -77,21 +73,11 @@ module.exports = {
             // on supprime le rôle de l'an dernier
             if(member.roles.cache.some(role => role.name == 'Licencié '+(year - 1))) {
               member.roles.remove(pastYearlyRole)
-              Response.setDescription(`
-                🐘 Ta licence ${year} a été validée !
-
-                Content de te retrouver aux Z\'éléph encore cette année !
-                `
-                )
+              Response.setDescription(TRANSLATION_LICENCE.successRenewMessage(year))
                 console.log(`${member.user.username } : licence ${Licence} re-validée pour ${year}`);
             } else {
               // Si nouveau membre, message de bienvenue
-              Response.setDescription(`
-                🐘 Bienvenue aux Z\'éléph !
-
-                Ta licence ${year} a été validée, tu as maintenant accès aux salons réservés aux membres du club.
-                `
-                )
+              Response.setDescription(TRANSLATION_LICENCE.successNewMessage(year))
               console.log(`${member.user.username } : nouvelle licence ${Licence} validée pour ${year}`);
             }
           } else {
@@ -106,13 +92,7 @@ module.exports = {
                 `)
               console.log(`${member.user.username } : licence ${Licence} invalide pour ${year}`);
             } else {
-              Response.setDescription(
-                `😱 Cette licence n\'est pas connue des Z\'éléph!
-
-                Mais pas de panique, rapproche toi d'un membre du comité pour que ton inscription soit prise en compte.
-
-                En attendant, tu as quand même accès aux salons de base.
-                `)
+              Response.setDescription(TRANSLATION_LICENCE.failureClub())
               console.log(`${member.user.username } : nouvelle licence ${Licence} non reconnue`);
             }
           }

--- a/Commands/Users/licence.js
+++ b/Commands/Users/licence.js
@@ -7,7 +7,7 @@ const { CommandInteraction, MessageEmbed } = require("discord.js")
 
 module.exports = {
   name: "licence",
-  description: "Vérification du numéro de licence FFVL",
+  description: TRANSLATION_LICENCE.description(),
   deferred: true,
   ephemeral: true,
   options: [
@@ -83,13 +83,7 @@ module.exports = {
           } else {
             Response.setColor("RED")
             if(member.roles.cache.some(role => role.name == 'Licencié '+year - 1)) {
-              Response.setDescription(
-                `😱 On dirait que ta licence n'est pas dans la liste de ${year}.
-
-                  Pas de panique, tu conserves tes accès Discord pour le moment.
-
-                  Rapproche toi rapidement d'un des membres du comité pour régler ça et ne pas perdre tes accès aux salons Discord.
-                `)
+              Response.setDescription(TRANSLATION_LICENCE.failureList(year))
               console.log(`${member.user.username } : licence ${Licence} invalide pour ${year}`);
             } else {
               Response.setDescription(TRANSLATION_LICENCE.failureClub())

--- a/Commands/Users/licencesCleanAll.js
+++ b/Commands/Users/licencesCleanAll.js
@@ -1,9 +1,10 @@
 const { CommandInteraction, MessageEmbed } = require("discord.js")
 const { mainRoleId } = require('../../config.json')
+const { TRANSLATION_LICENCE_CLEAN } = require('../../translation/messages.js')
 
 module.exports = {
   name: "licences_clean_all",
-  description: '⚠️ Suppression du rôle "Membre Zéléph" pour TOUS les membres n\'ayant pas renouvelé leur licence',
+  description: TRANSLATION_LICENCE_CLEAN.description(),
   permission: "ADMINISTRATOR",
   /**
    *
@@ -20,9 +21,7 @@ module.exports = {
     const mainRole = guild.roles.cache.find(role => role.id == mainRoleId)
 
     Response.setColor("RED")
-    Response.setDescription(`
-      Les membres n'ayant pas renouvelés leur licences vont voir leur rôle "Membre Z'éléph" retiré.
-      `)
+    Response.setDescription(TRANSLATION_LICENCE_CLEAN.successMessage())
     guild.members.cache.forEach((member) => {
       if(!member.roles.cache.some(role => role.name == 'Licencié '+year)) {
         // member.roles.remove(mainRole)

--- a/Events/Clients/newMember.js
+++ b/Events/Clients/newMember.js
@@ -1,5 +1,6 @@
 const { Client, MessageEmbed } = require("discord.js")
 const { newMemberRoleId, welcomeChannelId } = require('../../config.json')
+const { TRANSLATION_NEW_MEMBER } = require('../../translation/messages.js')
 
 module.exports = {
   name: 'guildMemberAdd',
@@ -13,25 +14,7 @@ module.exports = {
 
     const WelcomeMessage = new MessageEmbed()
       .setColor('RANDOM')
-      .setDescription(`
-        Bienvenue ${member} sur le Discord du club des Z'éléphants Volants !
-
-        Ce discord est là pour nous permettre d'échanger des infos, de planifier des sorties et événements, de finaliser leurs organisations opérationnelles, et d'en faire le compte-rendu.
-
-        Afin de faciliter l'organisation et la lisibilité, **il est souhaité que les pseudo affichés sur discord soient les vrais prénoms et la première lettre du nom (au moins)**. Cela peut être paramètré pour le serveur des z'éléphants volants dans votre profil serveur.
-
-        Si tu n'es pas membre du club des Z'éléphants Volants, ton accès au serveur est limité à quelques salons. **Pour avoir un accès complet au serveur, tu dois faire valider ta licence FFVL à notre robot.** Il suffit de taper le message **/licence** dans un salon et de renseigner ton numéro de licence FFVL.
-
-        Tu es nouveau au club  ? Alors n'hésite pas à aller te présenter dans le salon <#935798608396185641>.
-        Tu veux organiser une montée à Vérel ? Rendez-vous dans <#935238034918621264>.
-        Tu veux organiser une sortie un peu plus planifiée ? N'hésite pas à créer un salon dans la catégorie Planification de sorties !
-
-        Si tu as besoin d'aide sur l'outil Discord, le salon <#935247724088021002> est fait pour toi.
-
-        Enfin, retrouve tous les événements du club dans la catégorie Evénements calendriers et plein d'autres salons dans Vie du club.
-
-        Bonnes discussions, et surtout bons vols !
-      `)
+      .setDescription(TRANSLATION_NEW_MEMBER.welcome(member))
       const welcomeChannel = member.guild.channels.cache.get(welcomeChannelId) // salon Bienvenue
       welcomeChannel.send({embeds: [WelcomeMessage], ephemeral: true})
 

--- a/Handlers/Commands.js
+++ b/Handlers/Commands.js
@@ -4,7 +4,7 @@ const { promisify } = require("util");
 const { glob } = require("glob");
 const PG = promisify(glob);
 const Ascii = require("ascii-table");
-const { serverId } = require('../../config.json')
+const { serverId } = require('../config.json')
 
 /**
  * @param {Client} client

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Run the app : `node .`
 
 ## Prérequis
 
+
+### Configuration: 
 Il est nécessaire de créer un fichier config.json à la racine, ayant cette forme :
 
 ```
@@ -35,6 +37,11 @@ Il est nécessaire de créer un fichier config.json à la racine, ayant cette fo
   "licences": "array de licences FFVL"
 }
 ```
+
+### Traduction
+
+Les textes du bot sont définient dans le fichier `translation/messages.js`.
+Le script `preinstall`, executé automatiquement à l'installation de l'app va générer ce fichier sur la base du modèle `translation/messages.js`. 
 
 ## Fonctionnement
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "discord-bot-zeleph",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
         "ascii-table": "^0.0.9",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node index.js"
+    "start": "node index.js",
+    "preinstall": "cp -n translation/messages.exemple.js translation/messages.js"
   },
   "repository": {
     "type": "git",

--- a/translation/messages.exemple.js
+++ b/translation/messages.exemple.js
@@ -1,0 +1,29 @@
+// Licence module
+module.exports.TRANSLATION_LICENCE = {
+  commandDescription: () => "Renseignez votre numéro de licence FFVL pour rejoindre le discord des Z'éléph",
+  alreadyValidDescription: (year) =>
+    `
+    Ta licence ${year} est déjà validée, tout est bon pour cette année.
+
+    Bon vols !
+    `,
+  successRenewMessage: (year) =>
+    `
+    🐘 Ta licence ${year} a été validée !
+
+    Content de te retrouver aux Z\'éléph encore cette année !
+    `,
+  successNewMessage: (year) =>
+    `
+    🐘 Bienvenue aux Z\'éléph !
+
+    Ta licence ${year} a été validée, tu as maintenant accès aux salons réservés aux membres du club.
+    `,
+  failureClub: () =>
+    `😱 Cette licence n\'est pas connue des Z\'éléph!
+
+    Mais pas de panique, rapproche toi d'un membre du comité pour que ton inscription soit prise en compte.
+
+    En attendant, tu as quand même accès aux salons de base.
+    `,
+}

--- a/translation/messages.exemple.js
+++ b/translation/messages.exemple.js
@@ -1,5 +1,6 @@
-// Licence module
+// Commands licence
 module.exports.TRANSLATION_LICENCE = {
+  description: () => "Vérification du numéro de licence FFVL",
   commandDescription: () => "Renseignez votre numéro de licence FFVL pour rejoindre le discord des Z'éléph",
   alreadyValidDescription: (year) =>
     `
@@ -26,4 +27,43 @@ module.exports.TRANSLATION_LICENCE = {
 
     En attendant, tu as quand même accès aux salons de base.
     `,
+  failureList: (year) =>
+    `😱 On dirait que ta licence n'est pas dans la liste de ${year}.
+
+      Pas de panique, tu conserves tes accès Discord pour le moment.
+
+      Rapproche toi rapidement d'un des membres du comité pour régler ça et ne pas perdre tes accès aux salons Discord.
+    `,
+}
+
+// Commands clean licence
+module.exports.TRANSLATION_LICENCE_CLEAN = {
+  description: () => "⚠️ Suppression du rôle \"Membre Zéléh\" pour TOUS les membres n\\'ayant pas renouvelé leur licence'",
+  successMessage: () =>
+    `
+    Les membres n'ayant pas renouvelés leur licences vont voir leur rôle "Membre Z'éléph" retiré.
+    `,
+}
+
+// Events New Member
+module.exports.TRANSLATION_NEW_MEMBER= {
+  welcome: (member) => `
+        Bienvenue ${member} sur le Discord du club des Z'éléphants Volants !
+
+        Ce discord est là pour nous permettre d'échanger des infos, de planifier des sorties et événements, de finaliser leurs organisations opérationnelles, et d'en faire le compte-rendu.
+
+        Afin de faciliter l'organisation et la lisibilité, **il est souhaité que les pseudo affichés sur discord soient les vrais prénoms et la première lettre du nom (au moins)**. Cela peut être paramètré pour le serveur des z'éléphants volants dans votre profil serveur.
+
+        Si tu n'es pas membre du club des Z'éléphants Volants, ton accès au serveur est limité à quelques salons. **Pour avoir un accès complet au serveur, tu dois faire valider ta licence FFVL à notre robot.** Il suffit de taper le message **/licence** dans un salon et de renseigner ton numéro de licence FFVL.
+
+        Tu es nouveau au club  ? Alors n'hésite pas à aller te présenter dans le salon <#935798608396185641>.
+        Tu veux organiser une montée à Vérel ? Rendez-vous dans <#935238034918621264>.
+        Tu veux organiser une sortie un peu plus planifiée ? N'hésite pas à créer un salon dans la catégorie Planification de sorties !
+
+        Si tu as besoin d'aide sur l'outil Discord, le salon <#935247724088021002> est fait pour toi.
+
+        Enfin, retrouve tous les événements du club dans la catégorie Evénements calendriers et plein d'autres salons dans Vie du club.
+
+        Bonnes discussions, et surtout bons vols !
+      `
 }


### PR DESCRIPTION
Je n'ai pas trouvé plus simple pour gérer les template literals dans un fichier séparé. Si vous avez mieux, je prends :D 
Si ça vous va, je compléterais pour passer tous les textes.